### PR TITLE
SDK version bump --> 2.0.0-2, new clean-m + clean-w commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "main": "src/index.tsx",
   "scripts": {
     "dev": "ts-node src/index.tsx",
-    "clean": "rimraf node_modules && rimraf package-lock.json",
+    "clean-m": "rm -r node_modules && rm -r package-lock.json && rm -r build",
+    "clean-w": "rimraf node_modules && rimraf package-lock.json",
     "start": "cross-env react-scripts start",
     "build": "cross-env react-scripts build",
     "test": "jest"
   },
   "dependencies": {
-    "@pieces.app/pieces-os-client": "1.2.2",
+    "@pieces.app/pieces-os-client": "^2.0.0-2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",


### PR DESCRIPTION
**Description**

Quick patch update to accomplish a few things: 
- [x] update the version of SDK to latest 
- [x] added `clean-mac` and `clean-windows` commands for cleaning on both OS platforms & share 

The `npm run clean` command stopped working, and was only using rimraf - wanted to isolate these options and create more verbose commands for now.